### PR TITLE
Boton Filtro por marca

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,8 @@ pub fn run() {
             commands::equipos::transfer_equipo_to_cliente,            commands::ordenes_trabajo::get_ordenes_trabajo,
             commands::ordenes_trabajo::get_ordenes_trabajo_por_fecha,
             commands::ordenes_trabajo::get_ordenes_trabajo_by_prioridades,
+            commands::ordenes_trabajo::get_marcas_equipos,
+            commands::ordenes_trabajo::get_ordenes_trabajo_por_marca,
             commands::ordenes_trabajo::get_orden_trabajo_by_id,
             commands::ordenes_trabajo::get_orden_trabajo_by_codigo,
             commands::ordenes_trabajo::get_ordenes_trabajo_by_equipo,

--- a/src/components/views/FiltrarOrdenesPorMarca.tsx
+++ b/src/components/views/FiltrarOrdenesPorMarca.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { invoke } from "@tauri-apps/api/core";
+
+interface OrdenTrabajo {
+  orden_id: number;
+  orden_codigo?: string;
+  orden_desc?: string;
+  prioridad?: string;
+  estado?: string;
+  has_garantia?: boolean;
+  created_at?: string;
+}
+
+interface Props {
+  onFiltrar: (ordenes: OrdenTrabajo[]) => void;
+}
+
+export function FiltrarOrdenesPorMarca({ onFiltrar }: Props) {
+  const [marcas, setMarcas] = useState<string[]>([]);
+  const [marcaSeleccionada, setMarcaSeleccionada] = useState<string>("");
+  const [open, setOpen] = useState(false);
+
+  // Cargar marcas cuando se abre el modal
+  useEffect(() => {
+    if (!open) return;
+    (async () => {
+      try {
+        const data = await invoke<string[]>("get_marcas_equipos");
+        setMarcas(data);
+      } catch (err) {
+        console.error("Error cargando marcas:", err);
+        setMarcas([]);
+      }
+    })();
+  }, [open]);
+
+  const aplicarFiltro = async () => {
+    if (!marcaSeleccionada) return;
+    try {
+      const ordenes = await invoke<OrdenTrabajo[]>(
+        "get_ordenes_trabajo_por_marca",
+        { marca: marcaSeleccionada }
+      );
+      onFiltrar(ordenes);
+      setOpen(false);
+    } catch (err) {
+      console.error("Error filtrando por marca:", err);
+    }
+  };
+
+  const quitarFiltro = async () => {
+    try {
+      const ordenes = await invoke<OrdenTrabajo[]>("get_ordenes_trabajo");
+      onFiltrar(ordenes);
+      setMarcaSeleccionada("");
+      setOpen(false);
+    } catch (err) {
+      console.error("Error quitando filtro:", err);
+    }
+  };
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        Filtrar por Marca
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Filtrar por Marca</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-3 mt-2">
+            {marcas.length === 0 ? (
+              <p className="text-sm text-gray-500">
+                No hay marcas registradas.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {marcas.map((m) => (
+                  <label key={m} className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="marca"
+                      value={m}
+                      checked={marcaSeleccionada === m}
+                      onChange={(e) => setMarcaSeleccionada(e.target.value)}
+                    />
+                    <span>{m}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter className="mt-4">
+            <Button onClick={aplicarFiltro} disabled={!marcaSeleccionada}>
+              Aplicar
+            </Button>
+            <Button variant="outline" onClick={quitarFiltro}>
+              Quitar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/views/OrdenesTrabajoView.tsx
+++ b/src/components/views/OrdenesTrabajoView.tsx
@@ -17,6 +17,7 @@ import CotizacionFormDialog from "./CotizacionFormDialog";
 import InformeFormDialog from "./InformeFormDialog";
 import { FiltrarOrdenesPorFecha } from "./FiltrarOrdenesPorFecha";
 import { FiltrarOrdenesPorPrioridad } from "./FiltrarOrdenesPorPrioridad";
+import { FiltrarOrdenesPorMarca } from "./FiltrarOrdenesPorMarca";
 import { useToastContext } from "@/contexts/ToastContext";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -372,11 +373,14 @@ export function OrdenesTrabajoView() {
             Limpiar
           </Button>
         )}
-        {/* boton para las fechas */}
+        {/* boton para los filtos */}
         <FiltrarOrdenesPorFecha
           onFiltrar={(ordenesFiltradas) => setOrdenes(ordenesFiltradas)}
         />
         <FiltrarOrdenesPorPrioridad
+          onFiltrar={(ordenesFiltradas) => setOrdenes(ordenesFiltradas)}
+        />
+        <FiltrarOrdenesPorMarca
           onFiltrar={(ordenesFiltradas) => setOrdenes(ordenesFiltradas)}
         />
       </div>

--- a/src/components/views/index.ts
+++ b/src/components/views/index.ts
@@ -12,3 +12,4 @@ export * from "./PasswordResetView";
 export * from "./PiezasView";
 export * from "./FiltrarOrdenesPorFecha";
 export * from "./FiltrarOrdenesPorPrioridad";
+export * from "./FiltrarOrdenesPorMarca";


### PR DESCRIPTION
Se creo el boton filtrar por marca, en el cual se pueden seleccionar las marcas que estan registradas y al seleccionarlas solo aparecen las ordenes de trabajo con sus respectivas marcas, si no hay ninguna marca registrada no va a aparecer ninguna y estas se van a ir actualizando en el mismo momento en el que se ingresa un dispositivo con una marca nueva.