### PR TITLE
Add active/inactive state to clientes and filtering

### DIFF
--- a/src-tauri/migrations/002_create_cliente_table.sql
+++ b/src-tauri/migrations/002_create_cliente_table.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS CLIENTE (
     cliente_correo VARCHAR(256),
     cliente_telefono VARCHAR(16),
     cliente_direccion VARCHAR(512),
+    is_active BOOLEAN DEFAULT true,
     created_by INT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (created_by) REFERENCES USUARIO(usuario_id)

--- a/src-tauri/src/commands/clientes.rs
+++ b/src-tauri/src/commands/clientes.rs
@@ -12,6 +12,7 @@ pub struct Cliente {
     pub cliente_correo: Option<String>,
     pub cliente_telefono: Option<String>,
     pub cliente_direccion: Option<String>,
+    pub is_active: Option<bool>,
     pub created_by: Option<i32>,
     pub created_at: Option<DateTime<Utc>>,
 }
@@ -43,6 +44,7 @@ pub struct FiltrosClientes {
     pub rut: Option<Vec<String>>,    
     pub ciudad: Option<Vec<String>>,
     pub search: Option<String>,
+    pub estado: Option<Vec<bool>>,    
     pub ordenamiento: Option<String>,
 }
 
@@ -54,11 +56,15 @@ fn build_order_by_clause(ordenamiento: &Option<String>) -> String {
     }
 }
 
+// Consulta base actualizada para incluir is_active
+const BASE_SELECT: &str = "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, is_active, created_by, created_at FROM CLIENTE";
+
+
 #[tauri::command]
 pub async fn get_clientes() -> Result<Vec<Cliente>, String> {
     let pool = get_db_pool_safe()?;
     let clientes = sqlx::query_as::<_, Cliente>(
-        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by, created_at FROM CLIENTE ORDER BY cliente_nombre"
+        &format!("{} WHERE is_active = 1 ORDER BY cliente_nombre", BASE_SELECT)
     )
     .fetch_all(pool)
     .await
@@ -67,11 +73,12 @@ pub async fn get_clientes() -> Result<Vec<Cliente>, String> {
     Ok(clientes)
 }
 
+
 #[tauri::command]
 pub async fn get_cliente_by_id(cliente_id: i32) -> Result<Option<Cliente>, String> {
     let pool = get_db_pool_safe()?;
     let cliente = sqlx::query_as::<_, Cliente>(
-        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by, created_at FROM CLIENTE WHERE cliente_id = ?"
+        &format!("{} WHERE cliente_id = ?", BASE_SELECT)
     )
     .bind(cliente_id)
     .fetch_optional(pool)
@@ -85,7 +92,7 @@ pub async fn get_cliente_by_id(cliente_id: i32) -> Result<Option<Cliente>, Strin
 pub async fn get_cliente_by_rut(cliente_rut: String) -> Result<Option<Cliente>, String> {
     let pool = get_db_pool_safe()?;
     let cliente = sqlx::query_as::<_, Cliente>(
-        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by, created_at FROM CLIENTE WHERE cliente_rut = ?"
+        &format!("{} WHERE cliente_rut = ?", BASE_SELECT)
     )
     .bind(cliente_rut)
     .fetch_optional(pool)
@@ -99,7 +106,7 @@ pub async fn get_cliente_by_rut(cliente_rut: String) -> Result<Option<Cliente>, 
 pub async fn get_clientes_by_created_by(created_by: i32) -> Result<Vec<Cliente>, String> {
     let pool = get_db_pool_safe()?;
     let clientes = sqlx::query_as::<_, Cliente>(
-        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by, created_at FROM CLIENTE WHERE created_by = ? ORDER BY cliente_nombre"
+        &format!("{} WHERE created_by = ? AND is_active = 1 ORDER BY cliente_nombre", BASE_SELECT)
     )
     .bind(created_by)
     .fetch_all(pool)
@@ -115,10 +122,7 @@ pub async fn search_clientes(search_term: String) -> Result<Vec<Cliente>, String
     let search_pattern = format!("%{}%", search_term);
     
     let clientes = sqlx::query_as::<_, Cliente>(
-        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by, created_at 
-         FROM CLIENTE 
-         WHERE cliente_nombre LIKE ? OR cliente_rut LIKE ? OR cliente_correo LIKE ?
-         ORDER BY cliente_nombre"
+        &format!("{} WHERE (cliente_nombre LIKE ? OR cliente_rut LIKE ? OR cliente_correo LIKE ?) AND is_active = 1 ORDER BY cliente_nombre", BASE_SELECT)
     )
     .bind(&search_pattern)
     .bind(&search_pattern)
@@ -140,7 +144,7 @@ pub async fn create_cliente(request: CreateClienteRequest) -> Result<Cliente, St
     }
     
     let result = sqlx::query(
-        "INSERT INTO CLIENTE (cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by) VALUES (?, ?, ?, ?, ?, ?)"
+        "INSERT INTO CLIENTE (cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, is_active, created_by) VALUES (?, ?, ?, ?, ?, 1, ?)"
     )
     .bind(&request.cliente_rut)
     .bind(&request.cliente_nombre)
@@ -241,47 +245,53 @@ pub async fn update_cliente(cliente_id: i32, request: UpdateClienteRequest, upda
 pub async fn delete_cliente(cliente_id: i32, deleted_by: i32) -> Result<bool, String> {
     let pool = get_db_pool_safe()?;
     
-    // Obtener el cliente antes de eliminarlo para logging
+    // Obtener el cliente antes de inactivarlo para logging
     let cliente_to_delete = get_cliente_by_id(cliente_id).await?;
     
-    // Verificar si el cliente tiene cotizaciones, informes u órdenes de trabajo asociadas
-    let has_dependencies = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM (
-            SELECT 1 FROM COTIZACION WHERE cliente_id = ?
-            UNION ALL
-            SELECT 1 FROM INFORME WHERE cliente_id = ?
-            UNION ALL
-            SELECT 1 FROM ORDEN_TRABAJO WHERE cliente_id = ?
-        ) as dependencies"
+    // Verificar si el cliente existe y está activo
+    let cliente_exists = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM CLIENTE WHERE cliente_id = ? AND is_active = 1"
     )
     .bind(cliente_id)
-    .bind(cliente_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| format!("Database error checking client existence: {}", e))?;
+    
+    if cliente_exists == 0 {
+        return Err("No se puede inactivar el cliente porque no existe o ya está inactivo".to_string());
+    }
+    
+    // Verificar si el cliente tiene equipos asociados
+    let has_dependencies = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM EQUIPO WHERE cliente_id = ?"
+    )
     .bind(cliente_id)
     .fetch_one(pool)
     .await
     .map_err(|e| format!("Database error checking dependencies: {}", e))?;
-    
+
     if has_dependencies > 0 {
-        return Err("No se puede eliminar el cliente porque tiene cotizaciones, informes u órdenes de trabajo asociadas".to_string());
+        return Err("No se puede inactivar el cliente porque tiene equipos asociados".to_string());
     }
     
-    let result = sqlx::query("DELETE FROM CLIENTE WHERE cliente_id = ?")
+    // Marcar el cliente como inactivo en lugar de eliminarlo
+    let result = sqlx::query("UPDATE CLIENTE SET is_active = 0 WHERE cliente_id = ?")
         .bind(cliente_id)
         .execute(pool)
         .await
         .map_err(|e| format!("Database error: {}", e))?;
     
-    let was_deleted = result.rows_affected() > 0;
+    let was_inactivated = result.rows_affected() > 0;
     
     // Registrar la acción en el log de auditoría
-    if was_deleted {
+    if was_inactivated {
         if let Some(ref cliente) = cliente_to_delete {
             let _ = log_action(
-                "DELETE_CLIENTE",
+                "INACTIVATE_CLIENTE",
                 Some(deleted_by),
                 "CLIENTE",
                 Some(cliente_id),
-                Some(&format!("Cliente eliminado: {} ({})", 
+                Some(&format!("Cliente inactivado: {} ({})", 
                     cliente.cliente_nombre.as_deref().unwrap_or("N/A"),
                     cliente.cliente_correo.as_deref().unwrap_or("N/A")
                 )),
@@ -290,13 +300,63 @@ pub async fn delete_cliente(cliente_id: i32, deleted_by: i32) -> Result<bool, St
         }
     }
     
-    Ok(was_deleted)
+    Ok(was_inactivated)
+}
+
+// NUEVA FUNCIÓN: Reactivar cliente
+#[tauri::command]
+pub async fn reactivate_cliente(cliente_id: i32, reactivated_by: i32) -> Result<bool, String> {
+    let pool = get_db_pool_safe()?;
+    
+    // Obtener el cliente antes de reactivarlo para logging
+    let cliente_to_reactivate = get_cliente_by_id(cliente_id).await?;
+    
+    // Verificar si el cliente existe y está inactivo
+    let cliente_exists = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM CLIENTE WHERE cliente_id = ? AND is_active = 0"
+    )
+    .bind(cliente_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| format!("Database error checking client existence: {}", e))?;
+    
+    if cliente_exists == 0 {
+        return Err("No se puede reactivar el cliente porque no existe o ya está activo".to_string());
+    }
+    
+    // Marcar el cliente como activo
+    let result = sqlx::query("UPDATE CLIENTE SET is_active = 1 WHERE cliente_id = ?")
+        .bind(cliente_id)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("Database error: {}", e))?;
+    
+    let was_reactivated = result.rows_affected() > 0;
+    
+    // Registrar la acción en el log de auditoría
+    if was_reactivated {
+        if let Some(ref cliente) = cliente_to_reactivate {
+            let _ = log_action(
+                "REACTIVATE_CLIENTE",
+                Some(reactivated_by),
+                "CLIENTE",
+                Some(cliente_id),
+                Some(&format!("Cliente reactivado: {} ({})", 
+                    cliente.cliente_nombre.as_deref().unwrap_or("N/A"),
+                    cliente.cliente_correo.as_deref().unwrap_or("N/A")
+                )),
+                None
+            ).await;
+        }
+    }
+    
+    Ok(was_reactivated)
 }
 
 #[tauri::command]
 pub async fn count_clientes() -> Result<i64, String> {
     let pool = get_db_pool_safe()?;
-    let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM CLIENTE")
+    let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM CLIENTE WHERE is_active = 1")
         .fetch_one(pool)
         .await
         .map_err(|e| format!("Database error: {}", e))?;
@@ -304,14 +364,12 @@ pub async fn count_clientes() -> Result<i64, String> {
     Ok(count)
 }
 
+
 #[tauri::command]
 pub async fn get_clientes_with_pagination(offset: i64, limit: i64) -> Result<Vec<Cliente>, String> {
     let pool = get_db_pool_safe()?;
     let clientes = sqlx::query_as::<_, Cliente>(
-        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by, created_at 
-         FROM CLIENTE 
-         ORDER BY cliente_nombre 
-         LIMIT ? OFFSET ?"
+        &format!("{} WHERE is_active = 1 ORDER BY cliente_nombre LIMIT ? OFFSET ?", BASE_SELECT)
     )
     .bind(limit)
     .bind(offset)
@@ -323,18 +381,34 @@ pub async fn get_clientes_with_pagination(offset: i64, limit: i64) -> Result<Vec
 }
 
 
-// Unificar Filtros
+// Unificar Filtros 
 #[tauri::command]
 pub async fn get_clientes_filtrados(filtros: FiltrosClientes) -> Result<Vec<Cliente>, String> {
     let pool = get_db_pool_safe()?;
 
     let mut query = String::from(
-        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, created_by, created_at 
+        "SELECT cliente_id, cliente_rut, cliente_nombre, cliente_correo, cliente_telefono, cliente_direccion, is_active, created_by, created_at 
          FROM CLIENTE 
          WHERE 1=1"
     );
 
     let mut params: Vec<String> = Vec::new();
+
+    // Filtro por estado (activo/inactivo)
+    if let Some(estados) = filtros.estado {
+        if !estados.is_empty() {
+            if estados.len() == 1 {
+                // Solo un estado seleccionado
+                let estado = if estados[0] { 1 } else { 0 };
+                query.push_str(" AND is_active = ?");
+                params.push(estado.to_string());
+            }
+            // Si ambos están seleccionados, no agregar filtro (mostrar todos)
+        }
+    } else {
+        // Si no se especifica filtro de estado, mostrar solo activos por defecto
+        query.push_str(" AND is_active = 1");
+    }
 
     //  Filtro por búsqueda de texto 
     if let Some(search_term) = filtros.search {
@@ -344,6 +418,7 @@ pub async fn get_clientes_filtrados(filtros: FiltrosClientes) -> Result<Vec<Clie
             params.push(search_pattern);
         }
     }
+    
     // Filtro por fecha
     if let Some(fecha_inicio) = filtros.fecha_inicio {
         query.push_str(" AND date(created_at) >= date(?)");
@@ -388,9 +463,8 @@ pub async fn get_clientes_filtrados(filtros: FiltrosClientes) -> Result<Vec<Clie
         }
     }
 
-    // NUEVO: Agregar cláusula ORDER BY según el ordenamiento solicitado
+    // Agregar cláusula ORDER BY según el ordenamiento solicitado
     query.push_str(&build_order_by_clause(&filtros.ordenamiento));
-
 
     // Ejecutar consulta
     let mut q = sqlx::query_as::<_, Cliente>(&query);
@@ -405,7 +479,7 @@ pub async fn get_clientes_filtrados(filtros: FiltrosClientes) -> Result<Vec<Clie
     Ok(clientes)
 }
 
-// Función para obtener RUTs únicos
+// Función para obtener RUTs únicos 
 #[derive(Debug, FromRow)]
 struct RutResult {
     cliente_rut: Option<String>,
@@ -430,7 +504,7 @@ pub async fn get_ruts_clientes() -> Result<Vec<String>, String> {
     Ok(lista)
 }
 
-// Función para obtener correos únicos
+// Función para obtener correos únicos 
 #[derive(Debug, FromRow)]
 struct CorreoResult {
     cliente_correo: Option<String>,
@@ -455,7 +529,7 @@ pub async fn get_correos_clientes() -> Result<Vec<String>, String> {
     Ok(lista)
 }
 
-// Función para obtener ciudades únicas
+// Función para obtener ciudades únicas 
 #[derive(Debug, FromRow)]
 struct CiudadResult {
     cliente_direccion: Option<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,7 @@ pub fn run() {
             commands::clientes::create_cliente,
             commands::clientes::update_cliente,
             commands::clientes::delete_cliente,
+            commands::clientes::reactivate_cliente,
             commands::clientes::count_clientes,
             commands::clientes::get_clientes_with_pagination,
             commands::clientes::get_clientes_filtrados,

--- a/src/components/views/ClientesView.tsx
+++ b/src/components/views/ClientesView.tsx
@@ -59,6 +59,10 @@ export function ClientesView() {
     }
   };
 
+  const handleClearSearch = () => {
+    setSearchTerm("");
+  };
+
   //  Prevenir entrada de números al escribir
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     // Prevenir números (0-9)
@@ -183,7 +187,7 @@ export function ClientesView() {
 
       {/* Barra de búsqueda */}
       <div className="flex items-center space-x-2 mb-4">
-        <div className="relative flex-1 max-w-sm">
+        <div className="relative w-auto">
           <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
             ref={searchInputRef}
@@ -197,11 +201,12 @@ export function ClientesView() {
         </div>
 
         {/*  Filtros unificados - pasamos searchTerm y función para recibir resultados */}
-        <div className="flex-shrink-0">
+        <div className="flex-grow min-w-0">
           <UnificarFiltrosClientes
             key={refreshFilters}
             searchTerm={searchTerm}
             onFiltrar={handleClientesFiltrados}
+            onClearSearch={handleClearSearch}
           />
         </div>
       </div>

--- a/src/components/views/FiltrarClientesActivoseInactivos.tsx
+++ b/src/components/views/FiltrarClientesActivoseInactivos.tsx
@@ -1,0 +1,121 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+
+interface Props {
+  resetKey?: number;
+  onChange: (estados: boolean[] | null) => void;
+}
+
+export function FiltrarClienteActivoeInactivos({ resetKey, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const [seleccionados, setSeleccionados] = useState<boolean[]>([]);
+
+  // Opciones disponibles
+  const opcionesEstado = [
+    { valor: true, etiqueta: "Clientes Activos" },
+    { valor: false, etiqueta: "Clientes Inactivos" },
+  ];
+
+  // Reset automático cuando cambia resetKey
+  useEffect(() => {
+    setSeleccionados([]);
+  }, [resetKey]);
+
+  const toggleSeleccion = (estado: boolean) => {
+    setSeleccionados((prev) =>
+      prev.includes(estado)
+        ? prev.filter((s) => s !== estado)
+        : [...prev, estado]
+    );
+  };
+
+  const limpiar = () => {
+    setSeleccionados([]);
+    onChange(null);
+  };
+
+  const aplicarFiltro = () => {
+    onChange(seleccionados.length > 0 ? seleccionados : null);
+    setOpen(false);
+  };
+
+  // Función para obtener el texto del botón
+  const obtenerTextoBoton = () => {
+    if (seleccionados.length === 0) {
+      return "Activos/Inactivos";
+    }
+
+    if (seleccionados.length === 2) {
+      return "Todos los Estados";
+    }
+
+    if (seleccionados.includes(true)) {
+      return "Solo Activos";
+    }
+
+    return "Solo Inactivos";
+  };
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        {obtenerTextoBoton()}
+        {seleccionados.length > 0 && (
+          <span className="ml-1 bg-blue-100 text-blue-800 px-1 rounded text-xs flex items-center gap-1">
+            {seleccionados.length}
+            <button
+              onClick={(e) => {
+                e.stopPropagation(); // evita cerrar el diálogo
+                limpiar();
+              }}
+              className="ml-1 text-red-500 hover:text-red-700 font-bold text-lg leading-none hover:bg-red-200 rounded-full px-1"
+            >
+              ×
+            </button>
+          </span>
+        )}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Filtrar por Estado del Cliente</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            {opcionesEstado.map((opcion) => (
+              <div
+                key={opcion.valor.toString()}
+                className="flex items-center space-x-2"
+              >
+                <Checkbox
+                  checked={seleccionados.includes(opcion.valor)}
+                  onCheckedChange={() => toggleSeleccion(opcion.valor)}
+                />
+                <span className="text-sm font-medium">{opcion.etiqueta}</span>
+              </div>
+            ))}
+          </div>
+
+          <DialogFooter className="flex gap-2">
+            <Button onClick={aplicarFiltro}>
+              Aplicar
+              {seleccionados.length > 0 && ` (${seleccionados.length})`}
+            </Button>
+            <Button variant="outline" onClick={limpiar}>
+              Limpiar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/views/FiltrarClientesPorCiudad.tsx
+++ b/src/components/views/FiltrarClientesPorCiudad.tsx
@@ -109,9 +109,12 @@ export function FiltrarClientesPorCiudad({ resetKey, onChange }: Props) {
             ))}
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="flex gap-2">
             <Button onClick={aplicarFiltro}>
               Aplicar {seleccionados.length > 0 && `(${seleccionados.length})`}
+            </Button>
+            <Button variant="outline" onClick={limpiar}>
+              Limpiar
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/views/FiltrarClientesPorCorreo.tsx
+++ b/src/components/views/FiltrarClientesPorCorreo.tsx
@@ -109,9 +109,12 @@ export function FiltrarClientesPorCorreo({ resetKey, onChange }: Props) {
             ))}
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="flex gap-2">
             <Button onClick={aplicarFiltro}>
               Aplicar {seleccionados.length > 0 && `(${seleccionados.length})`}
+            </Button>
+            <Button variant="outline" onClick={limpiar}>
+              Limpiar
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/views/FiltrarClientesPorRuts.tsx
+++ b/src/components/views/FiltrarClientesPorRuts.tsx
@@ -117,9 +117,12 @@ export function FiltrarClientesPorRuts({ resetKey, onChange }: Props) {
             ))}
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="flex gap-2">
             <Button onClick={aplicarFiltro}>
               Aplicar {seleccionados.length > 0 && `(${seleccionados.length})`}
+            </Button>
+            <Button variant="outline" onClick={limpiar}>
+              Limpiar
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/views/UnificarFiltrosClientes.tsx
+++ b/src/components/views/UnificarFiltrosClientes.tsx
@@ -5,6 +5,7 @@ import { FiltrarOrdenesPorFechaClientes } from "./FiltrarOrdenesPorFechaClientes
 import { FiltrarClientesPorCorreo } from "./FiltrarClientesPorCorreo";
 import { FiltrarClientesPorRuts } from "./FiltrarClientesPorRuts";
 import { FiltrarClientesPorCiudad } from "./FiltrarClientesPorCiudad";
+import { FiltrarClienteActivoeInactivos } from "./FiltrarClientesActivoseInactivos.tsx";
 import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 
 interface Cliente {
@@ -14,6 +15,7 @@ interface Cliente {
   cliente_correo?: string;
   cliente_telefono?: string;
   cliente_direccion?: string;
+  is_active?: boolean;
   created_by?: number;
   created_at?: string;
 }
@@ -23,9 +25,14 @@ type OrdenTipo = "ninguno" | "asc" | "desc";
 interface Props {
   onFiltrar: (clientes: Cliente[]) => void;
   searchTerm?: string;
+  onClearSearch?: () => void; // Nueva prop para limpiar la búsqueda
 }
 
-export function UnificarFiltrosClientes({ onFiltrar, searchTerm }: Props) {
+export function UnificarFiltrosClientes({
+  onFiltrar,
+  searchTerm,
+  onClearSearch,
+}: Props) {
   const filtrosIniciales = {
     fecha_inicio: null as string | null,
     fecha_fin: null as string | null,
@@ -33,6 +40,7 @@ export function UnificarFiltrosClientes({ onFiltrar, searchTerm }: Props) {
     rut: null as string[] | null,
     ciudad: null as string[] | null,
     search: null as string | null,
+    estado: null as boolean[] | null, // ← NUEVO CAMPO
   };
 
   const [filtros, setFiltros] = useState(filtrosIniciales);
@@ -113,12 +121,13 @@ export function UnificarFiltrosClientes({ onFiltrar, searchTerm }: Props) {
         filtros.correo !== null ||
         filtros.rut !== null ||
         filtros.ciudad !== null ||
-        filtros.search !== null;
+        filtros.search !== null ||
+        filtros.estado !== null;
 
       let clientes: Cliente[];
 
       if (!hayFiltrosActivos) {
-        // Sin filtros, obtener todos los clientes
+        // Sin filtros, obtener todos los clientes activos por defecto
         clientes = await invoke<Cliente[]>("get_clientes");
       } else {
         // Con filtros, usar el endpoint de filtrado
@@ -129,6 +138,7 @@ export function UnificarFiltrosClientes({ onFiltrar, searchTerm }: Props) {
           rut: filtros.rut,
           ciudad: filtros.ciudad,
           search: filtros.search,
+          estado: filtros.estado,
         };
 
         console.log("📤 Enviando al backend:", filtrosParaBackend);
@@ -166,20 +176,26 @@ export function UnificarFiltrosClientes({ onFiltrar, searchTerm }: Props) {
     aplicarFiltros();
   }, [filtros]);
 
-  //  Verificar si hay filtros activos (incluyendo búsqueda)
+  //  Verificar si hay filtros activos (incluyendo búsqueda y estado)
   const hayFiltrosActivos =
     filtros.fecha_inicio !== null ||
     filtros.fecha_fin !== null ||
     filtros.correo !== null ||
     filtros.rut !== null ||
     filtros.ciudad !== null ||
-    filtros.search !== null;
+    filtros.search !== null ||
+    filtros.estado !== null; //
 
-  //  Limpiar todos los filtros (incluyendo búsqueda y ordenamiento)
+  //  Limpiar todos los filtros (incluyendo búsqueda, estado y ordenamiento)
   const limpiarFiltros = () => {
     setFiltros(filtrosIniciales);
     setOrdenamiento("ninguno");
     setResetKey((prev) => prev + 1);
+
+    // Limpiar la búsqueda en el componente padre
+    if (onClearSearch) {
+      onClearSearch();
+    }
   };
 
   //  Función para obtener el icono del botón de ordenamiento
@@ -230,6 +246,11 @@ export function UnificarFiltrosClientes({ onFiltrar, searchTerm }: Props) {
         onChange={(ciudades) => actualizarFiltro({ ciudad: ciudades })}
       />
 
+      <FiltrarClienteActivoeInactivos
+        resetKey={resetKey}
+        onChange={(estados) => actualizarFiltro({ estado: estados })}
+      />
+
       {/* Botón de ordenamiento alfabético */}
       <Button
         variant={ordenamiento !== "ninguno" ? "default" : "outline"}
@@ -249,7 +270,7 @@ export function UnificarFiltrosClientes({ onFiltrar, searchTerm }: Props) {
 
       {(hayFiltrosActivos || ordenamiento !== "ninguno") && (
         <Button variant="outline" onClick={limpiarFiltros} className="text-sm">
-          Limpiar Todo
+          Limpiar
         </Button>
       )}
     </div>

--- a/src/components/views/index.ts
+++ b/src/components/views/index.ts
@@ -20,3 +20,4 @@ export * from "./FiltrarOrdenesPorFechaClientes.tsx";
 export * from "./UnificarFiltrosClientes.tsx";
 export * from "./FiltrarClientesPorCorreo.tsx";
 export * from "./FiltrarClientesPorRuts.tsx";
+export * from "./FiltrarClientesActivoseInactivos.tsx";


### PR DESCRIPTION
Introduces an is_active field to the CLIENTE table and updates backend logic to support soft deletion (inactivation) and reactivation of clients. Adds filtering by active/inactive status in the unified filters, updates related SQL queries, and implements a new React component for filtering by client state. Also improves filter dialogs with a 'Limpiar' button and ensures only active clients are shown by default.