### PR TITLE
Rename SettingsView to AjustesDeCuentaView and improve phone validation

### DIFF
--- a/src-tauri/src/commands/users.rs
+++ b/src-tauri/src/commands/users.rs
@@ -653,9 +653,9 @@ pub async fn validate_session(session_token: String) -> Result<Option<Usuario>, 
     
     // Buscar usuario por token de sesión válido y no expirado
     let usuario = sqlx::query_as::<_, Usuario>(
-        "SELECT usuario_id, usuario_rut, usuario_nombre, usuario_correo, usuario_contrasena, usuario_telefono, usuario_rol, last_login_at, session_expires_at, session_token
+        "SELECT usuario_id, usuario_rut, usuario_nombre, usuario_correo, usuario_contrasena, usuario_telefono, usuario_rol, is_active, last_login_at, session_expires_at, session_token
          FROM USUARIO 
-         WHERE session_token = ? AND session_expires_at > UTC_TIMESTAMP()"
+         WHERE session_token = ? AND session_expires_at > UTC_TIMESTAMP() AND is_active = TRUE"
     )
     .bind(&session_token)
     .fetch_optional(pool)
@@ -956,5 +956,23 @@ pub async fn verify_rut_in_use(rut: String) -> bool {
         },
         Err(_) => false,
     }
+}
+
+#[tauri::command]
+pub fn verify_phone(phone: String) -> bool {
+    if phone.len() > 12 {
+        return false;
+    }
+    let chars: Vec<char> = phone.chars().collect();
+    if chars.is_empty() || chars[0] != '+' {
+        return false;
+    }
+    if chars.len() == 1 {
+        return false;
+    }
+    if !chars[1..].iter().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    true
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
             commands::users::verify_email_in_use,
             commands::users::verify_email,
             commands::users::verify_rut_in_use,
+            commands::users::verify_phone,
             commands::users::send_password_email,
             commands::logs::create_audit_log,
             commands::logs::get_audit_log_by_id,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import {
   EquiposView,
   ClientesView,
   OrdenesTrabajoView,
-  SettingsView,
+  AjustesDeCuentaView,
   HelpView,
   PiezasView,
   UsuarioView,
@@ -45,8 +45,8 @@ function ViewRenderer() {
     case "usuarios":
       return <UsuarioView />;
     case "projects":
-    case "settings":
-      return <SettingsView />;
+    case "Ajustes de Cuenta":
+      return <AjustesDeCuentaView />;
     case "gethelp":
       return <HelpView />;
     default:

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -57,7 +57,7 @@ const data = {
   ],
   navSecondary: [
     {
-      title: "Settings",
+      title: "Ajustes de Cuenta",
       url: "#",
       icon: IconSettings,
     },

--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -29,7 +29,7 @@ export function NavSecondary({
         <SidebarMenu>
           {items.map((item) => {
             // Convertir el título a camelCase para el ID de la vista
-            const viewId = item.title.toLowerCase().replace(/\s+/g, "");
+            const viewId = item.title;
             const isActive = currentView === viewId;
 
             return (

--- a/src/components/views/AjustesDeCuentaView.tsx
+++ b/src/components/views/AjustesDeCuentaView.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useAuth } from "@/contexts/AuthContext";
@@ -17,29 +15,15 @@ import {
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { IconCheck, IconX, IconEye, IconEyeOff } from "@tabler/icons-react";
 
-interface ChangePasswordRequest {
-  current_password: string;
-  new_password: string;
-}
 
 interface ChangeEmailRequest {
   new_email: string;
   password: string;
 }
 
-export function SettingsView() {
+export function AjustesDeCuentaView() {
   const { user, validateSession } = useAuth();
 
-  // Estados para cambio de contraseña
-  const [currentPassword, setCurrentPassword] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
-  const [showNewPassword, setShowNewPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [isChangingPassword, setIsChangingPassword] = useState(false);
-  const [passwordSuccess, setPasswordSuccess] = useState("");
-  const [passwordError, setPasswordError] = useState("");
 
   // Estados para cambio de email
   const [newEmail, setNewEmail] = useState("");
@@ -57,59 +41,6 @@ export function SettingsView() {
   const [phoneSuccess, setPhoneSuccess] = useState("");
   const [phoneError, setPhoneError] = useState("");
 
-  const handleChangePassword = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setPasswordError("");
-    setPasswordSuccess("");
-
-    // Validaciones
-    if (newPassword.length < 6) {
-      setPasswordError("La nueva contraseña debe tener al menos 6 caracteres");
-      return;
-    }
-
-    if (newPassword !== confirmPassword) {
-      setPasswordError("Las contraseñas no coinciden");
-      return;
-    }
-
-    if (currentPassword === newPassword) {
-      setPasswordError("La nueva contraseña debe ser diferente a la actual");
-      return;
-    }
-
-    setIsChangingPassword(true);
-
-    try {
-      const request: ChangePasswordRequest = {
-        current_password: currentPassword,
-        new_password: newPassword,
-      };
-
-      const result = await invoke<boolean>("change_user_password", {
-        usuarioId: user!.usuario_id,
-        request,
-      });
-
-      if (result) {
-        setPasswordSuccess("Contraseña cambiada exitosamente");
-        setCurrentPassword("");
-        setNewPassword("");
-        setConfirmPassword("");
-      } else {
-        setPasswordError("No se pudo cambiar la contraseña");
-      }
-    } catch (error) {
-      const errorMessage = String(error);
-      if (errorMessage.includes("Contraseña actual incorrecta")) {
-        setPasswordError("La contraseña actual es incorrecta");
-      } else {
-        setPasswordError("Error al cambiar la contraseña: " + errorMessage);
-      }
-    } finally {
-      setIsChangingPassword(false);
-    }
-  };
 
   const handleChangeEmail = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -127,9 +58,16 @@ export function SettingsView() {
       return;
     }
 
+    // Validar email en uso usando Tauri
     setIsChangingEmail(true);
-
     try {
+      const emailEnUso = await invoke<boolean>("verify_email_in_use", { correo: newEmail });
+      if (emailEnUso) {
+        setEmailError("Este email ya está en uso por otro usuario");
+        setIsChangingEmail(false);
+        return;
+      }
+
       const request: ChangeEmailRequest = {
         new_email: newEmail,
         password: emailPassword,
@@ -169,9 +107,15 @@ export function SettingsView() {
     setPhoneError("");
     setPhoneSuccess("");
 
-    // Validaciones
-    if (newPhone.length < 9) {
-      setPhoneError("El nuevo teléfono debe tener al menos 9 dígitos");
+    // Validar formato usando Tauri verify_phone
+    try {
+      const isValid = await invoke<boolean>("verify_phone", { phone: newPhone });
+      if (!isValid) {
+        setPhoneError("El teléfono debe iniciar con '+' y tener solo números, máximo 12 caracteres.");
+        return;
+      }
+    } catch (err) {
+      setPhoneError("Error al validar el formato del teléfono");
       return;
     }
 
@@ -183,14 +127,9 @@ export function SettingsView() {
     setIsChangingPhone(true);
 
     try {
-      const request = {
-        new_phone: newPhone,
-        password: phonePassword,
-      };
-
-      const result = await invoke<any>("change_user_phone", {
+      const result = await invoke<any>("update_usuario", {
         usuarioId: user!.usuario_id,
-        request,
+        request: { usuario_telefono: newPhone },
       });
 
       if (result) {
@@ -203,11 +142,7 @@ export function SettingsView() {
       }
     } catch (error) {
       const errorMessage = String(error);
-      if (errorMessage.includes("Contraseña incorrecta")) {
-        setPhoneError("La contraseña es incorrecta");
-      } else {
-        setPhoneError("Error al cambiar el teléfono: " + errorMessage);
-      }
+      setPhoneError("Error al cambiar el teléfono: " + errorMessage);
     } finally {
       setIsChangingPhone(false);
     }
@@ -229,7 +164,7 @@ export function SettingsView() {
   }
   return (
     <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-      <ViewTitle />
+  <ViewTitle />
 
       <div className="flex justify-center">
         <div className="grid gap-6 max-w-2xl w-full">
@@ -265,142 +200,16 @@ export function SettingsView() {
                     {user.usuario_rol || "Sin rol"}
                   </p>
                 </div>
+                <div>
+                  <Label className="text-sm font-medium">Teléfono</Label>
+                  <p className="text-sm text-muted-foreground">
+                    {user.usuario_telefono || "Sin teléfono"}
+                  </p>
+                </div>
               </div>
             </CardContent>
           </Card>
 
-          {/* Cambiar contraseña */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Cambiar Contraseña</CardTitle>
-              <CardDescription>
-                Cambia tu contraseña actual por una nueva
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handleChangePassword} className="space-y-4">
-                {passwordSuccess && (
-                  <Alert className="border-green-200 bg-green-50">
-                    <IconCheck className="h-4 w-4 text-green-600" />
-                    <AlertDescription className="text-green-800">
-                      {passwordSuccess}
-                    </AlertDescription>
-                  </Alert>
-                )}
-
-                {passwordError && (
-                  <Alert className="border-red-200 bg-red-50">
-                    <IconX className="h-4 w-4 text-red-600" />
-                    <AlertDescription className="text-red-800">
-                      {passwordError}
-                    </AlertDescription>
-                  </Alert>
-                )}
-
-                <div className="space-y-2">
-                  <Label htmlFor="current-password">Contraseña actual</Label>
-                  <div className="relative">
-                    <Input
-                      id="current-password"
-                      type={showCurrentPassword ? "text" : "password"}
-                      value={currentPassword}
-                      onChange={(e) => setCurrentPassword(e.target.value)}
-                      required
-                      disabled={isChangingPassword}
-                      className="pr-10"
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                      onClick={() =>
-                        setShowCurrentPassword(!showCurrentPassword)
-                      }
-                    >
-                      {showCurrentPassword ? (
-                        <IconEyeOff className="h-4 w-4" />
-                      ) : (
-                        <IconEye className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="new-password">Nueva contraseña</Label>
-                  <div className="relative">
-                    <Input
-                      id="new-password"
-                      type={showNewPassword ? "text" : "password"}
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                      required
-                      disabled={isChangingPassword}
-                      className="pr-10"
-                      minLength={6}
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                      onClick={() => setShowNewPassword(!showNewPassword)}
-                    >
-                      {showNewPassword ? (
-                        <IconEyeOff className="h-4 w-4" />
-                      ) : (
-                        <IconEye className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="confirm-password">
-                    Confirmar nueva contraseña
-                  </Label>
-                  <div className="relative">
-                    <Input
-                      id="confirm-password"
-                      type={showConfirmPassword ? "text" : "password"}
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      required
-                      disabled={isChangingPassword}
-                      className="pr-10"
-                      minLength={6}
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                      onClick={() =>
-                        setShowConfirmPassword(!showConfirmPassword)
-                      }
-                    >
-                      {showConfirmPassword ? (
-                        <IconEyeOff className="h-4 w-4" />
-                      ) : (
-                        <IconEye className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-
-                <Button
-                  type="submit"
-                  disabled={isChangingPassword}
-                  className="w-full"
-                >
-                  {isChangingPassword
-                    ? "Cambiando contraseña..."
-                    : "Cambiar contraseña"}
-                </Button>
-              </form>
-            </CardContent>
-          </Card>
 
           {/* Cambiar email */}
           <Card>
@@ -520,8 +329,8 @@ export function SettingsView() {
                     required
                     disabled={isChangingPhone}
                     placeholder="+56912345678"
-                    minLength={9}
-                    maxLength={9}
+                    minLength={12}
+                    maxLength={12}
                   />
                 </div>
 

--- a/src/components/views/UsuarioFormDialog.tsx
+++ b/src/components/views/UsuarioFormDialog.tsx
@@ -116,10 +116,12 @@ export function UsuarioFormDialog({
   const validateForm = async (): Promise<boolean> => {
   const newErrors: Record<string, string> = {};
 
-    // Validación de teléfono: mínimo 9 dígitos, solo números
-    const telefonoSoloNumeros = formData.usuario_telefono.replace(/[^0-9]/g, "");
-    if (telefonoSoloNumeros.length > 0 && telefonoSoloNumeros.length < 9) {
-      newErrors.usuario_telefono = "El teléfono debe tener al menos 9 dígitos";
+    // Validación de teléfono usando función Tauri
+    if (formData.usuario_telefono) {
+      const telefonoValido = await invoke<boolean>("verify_phone", { phone: formData.usuario_telefono });
+      if (!telefonoValido) {
+        newErrors.usuario_telefono = "El teléfono debe tener formato +569XXXXXXXX";
+      }
     }
 
     if (!formData.usuario_rut.trim()) {

--- a/src/components/views/index.ts
+++ b/src/components/views/index.ts
@@ -5,7 +5,7 @@ export * from "./ClientesView";
 export * from "./ClienteFormDialog";
 export * from "./OrdenesTrabajoView";
 export * from "./OrdenTrabajoFormDialog";
-export * from "./SettingsView";
+export * from "./AjustesDeCuentaView";
 export * from "./HelpView";
 export * from "./LoginView";
 export * from "./PasswordResetView";


### PR DESCRIPTION
Renamed SettingsView to AjustesDeCuentaView across the app for consistency with Spanish naming. Added and integrated a new Tauri command verify_phone for phone number format validation in user forms and account settings. Updated session validation to require active users. Removed password change logic from AjustesDeCuentaView and improved phone/email validation flows.