### PR TITLE
Feature/add new table

### DIFF
--- a/src-tauri/migrations/014_create_terminos_condiciones_table.sql
+++ b/src-tauri/migrations/014_create_terminos_condiciones_table.sql
@@ -1,0 +1,14 @@
+-- Crear tabla para términos y condiciones
+CREATE TABLE IF NOT EXISTS TERMINOS_CONDICIONES (
+    termino_id INT PRIMARY KEY AUTO_INCREMENT,
+    termino_nombre VARCHAR(128) NOT NULL,
+    termino_descripcion TEXT NOT NULL,
+    is_active BOOLEAN DEFAULT TRUE,
+    tipo_referencia ENUM('informe', 'cotizacion', 'ambos') NOT NULL,
+    is_default BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_tipo_referencia (tipo_referencia),
+    INDEX idx_is_active (is_active),
+    INDEX idx_is_default (is_default)
+);

--- a/src-tauri/migrations/015_create_terminos_informe_table.sql
+++ b/src-tauri/migrations/015_create_terminos_informe_table.sql
@@ -1,0 +1,10 @@
+-- Crear tabla de relación entre términos y condiciones con informes
+CREATE TABLE IF NOT EXISTS TERMINOS_INFORME (
+    termino_id INT,
+    informe_id INT,
+    aplicado BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (termino_id, informe_id),
+    FOREIGN KEY (termino_id) REFERENCES TERMINOS_CONDICIONES(termino_id) ON DELETE CASCADE,
+    FOREIGN KEY (informe_id) REFERENCES INFORME(informe_id) ON DELETE CASCADE
+);

--- a/src-tauri/migrations/016_create_terminos_cotizacion_table.sql
+++ b/src-tauri/migrations/016_create_terminos_cotizacion_table.sql
@@ -1,0 +1,10 @@
+-- Crear tabla de relación entre términos y condiciones con cotizaciones
+CREATE TABLE IF NOT EXISTS TERMINOS_COTIZACION (
+    termino_id INT,
+    cotizacion_id INT,
+    aplicado BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (termino_id, cotizacion_id),
+    FOREIGN KEY (termino_id) REFERENCES TERMINOS_CONDICIONES(termino_id) ON DELETE CASCADE,
+    FOREIGN KEY (cotizacion_id) REFERENCES COTIZACION(cotizacion_id) ON DELETE CASCADE
+);

--- a/src-tauri/migrations/017_insert_terminos_condiciones_ejemplos.sql
+++ b/src-tauri/migrations/017_insert_terminos_condiciones_ejemplos.sql
@@ -1,0 +1,10 @@
+-- Insertar términos y condiciones de ejemplo
+INSERT INTO TERMINOS_CONDICIONES (termino_nombre, termino_descripcion, tipo_referencia, is_default) VALUES
+('Garantía Estándar', 'Los trabajos de reparación tienen una garantía de 90 días a partir de la fecha de entrega del equipo.', 'ambos', TRUE),
+('Responsabilidad por Pérdida', 'El cliente es responsable de cualquier pérdida o daño del equipo mientras esté en nuestras instalaciones.', 'ambos', TRUE),
+('Condiciones de Pago', 'El pago debe realizarse antes de la entrega del equipo reparado. Se acepta efectivo, tarjeta o transferencia bancaria.', 'cotizacion', TRUE),
+('Diagnóstico Técnico', 'El diagnóstico técnico incluye la identificación de fallas y evaluación del estado general del equipo.', 'informe', TRUE),
+('Plazo de Retiro', 'El cliente tiene un plazo máximo de 30 días para retirar el equipo una vez notificada la finalización del trabajo.', 'ambos', FALSE),
+('Piezas de Repuesto', 'Las piezas utilizadas en la reparación son originales o equivalentes de calidad garantizada.', 'informe', FALSE),
+('Cotización Válida', 'Esta cotización tiene una validez de 15 días hábiles desde su fecha de emisión.', 'cotizacion', FALSE),
+('Trabajo No Garantizado', 'Trabajos realizados en equipos con daños por líquidos o golpes externos no tienen garantía.', 'ambos', FALSE);

--- a/src-tauri/src/email.rs
+++ b/src-tauri/src/email.rs
@@ -1,6 +1,5 @@
 use resend_rs::{Resend, types::CreateEmailBaseOptions};
 use std::env;
-use chrono::{DateTime, Utc, NaiveDateTime};
 use chrono_tz::America::Santiago;
 
 pub struct EmailService {


### PR DESCRIPTION
This pull request introduces a new system for managing "términos y condiciones" (terms and conditions) within the database, including tables for storing terms, linking them to reports and quotations, and providing example entries. These changes lay the groundwork for associating specific terms and conditions with reports and quotations, enhancing the flexibility and traceability of these documents.

**Database schema additions:**

* Added new table `TERMINOS_CONDICIONES` to store terms and conditions, including fields for name, description, reference type, active status, default status, and timestamps, with relevant indexes for efficient querying.

**Relationship tables:**

* Created `TERMINOS_INFORME` table to link terms and conditions to reports (`INFORME`), supporting cascading deletes and tracking application status and creation time.
* Created `TERMINOS_COTIZACION` table to link terms and conditions to quotations (`COTIZACION`), with similar structure and constraints as the report relationship table.

**Seed data:**

* Inserted sample terms and conditions into `TERMINOS_CONDICIONES`, covering common scenarios for reports and quotations, and setting defaults where appropriate.

**Minor code cleanup:**

* Removed unused imports from `src-tauri/src/email.rs` for improved code clarity.